### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 This Model Context Protocol (MCP) server provides a bridge between Claude and Google Tasks, allowing you to manage your task lists and tasks directly through Claude.
 
+<a href="https://glama.ai/mcp/servers/@arpitbatra123/mcp-googletasks">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@arpitbatra123/mcp-googletasks/badge" alt="Google Tasks Server MCP server" />
+</a>
+
 **Note:** All ( bar some edits ) code in this project was ["vibe coded"](https://en.wikipedia.org/wiki/Vibe_coding) - generated with Claude with instructions from me.
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [Google Tasks MCP Server](https://glama.ai/mcp/servers/@arpitbatra123/mcp-googletasks) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@arpitbatra123/mcp-googletasks">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@arpitbatra123/mcp-googletasks/badge" alt="Google Tasks Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.