### PR TITLE
feat(move-task): support destinationTasklist for cross-list moves

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1157,18 +1157,21 @@ server.registerTool(
 
 // 7. Move a task
 const moveTaskSchema = z.object({
-  tasklist: TaskListIdSchema.describe("Task list ID"),
+  tasklist: TaskListIdSchema.describe("Current task list ID"),
   task: TaskIdSchema.describe("Task ID to move"),
-  parent: TaskIdSchema.optional().describe("Optional new parent task ID"),
+  parent: TaskIdSchema.optional().describe("Optional new parent task ID (must be in the destination list if destinationTasklist is specified)"),
   previous: TaskIdSchema
     .optional()
-    .describe("Optional previous sibling task ID"),
+    .describe("Optional previous sibling task ID (must be in the destination list if destinationTasklist is specified)"),
+  destinationTasklist: TaskListIdSchema
+    .optional()
+    .describe("Optional destination task list ID. If set, the task is moved from `tasklist` to this list while preserving its task ID. Omit to reposition within the current list. Note: recurring tasks cannot be moved between lists (Google Tasks API limitation)."),
 });
 server.registerTool(
   "move-task",
   {
     title: "Move Task",
-    description: "Move a task to another position",
+    description: "Move a task to another position within the same list, or to a different list via destinationTasklist (task ID is preserved in both cases)",
     inputSchema: moveTaskSchema,
   },
   async (args: z.infer<typeof moveTaskSchema>) => {
@@ -1191,6 +1194,7 @@ server.registerTool(
         task: string;
         parent?: string;
         previous?: string;
+        destinationTasklist?: string;
       } = {
         tasklist: args.tasklist,
         task: args.task,
@@ -1198,6 +1202,7 @@ server.registerTool(
 
       if (args.parent !== undefined) moveParams.parent = args.parent;
       if (args.previous !== undefined) moveParams.previous = args.previous;
+      if (args.destinationTasklist !== undefined) moveParams.destinationTasklist = args.destinationTasklist;
 
       const response = await tasks.tasks.move(moveParams);
 


### PR DESCRIPTION
## Problem

The `move-task` tool currently only supports repositioning a task within the same task list. Moving a task to a different list requires delete + create, which changes the task ID and breaks any external references to it (e.g. sync state, logs, linked records in other systems).

## Solution

Add an optional `destinationTasklist` parameter to `move-task` that maps to the Google Tasks API [`tasks.move`](https://developers.google.com/tasks/reference/rest/v1/tasks/move) endpoint's `destinationTasklist` field. When set, the task is moved from `tasklist` to the destination list **while preserving its task ID**. When omitted, behavior is unchanged (reposition within the current list).

Schema and description updates:
- `destinationTasklist` added as an optional `TaskListIdSchema` field.
- `parent` / `previous` descriptions clarify they must belong to the destination list when `destinationTasklist` is set.
- Tool description updated to mention cross-list moves.

## Tested

- Verified that moving a task between lists with `destinationTasklist` preserves the task ID (same ID visible in the destination list after the call).
- Verified that omitting `destinationTasklist` continues to work for in-list reordering.

## Note

Recurring tasks cannot be moved between lists due to a Google Tasks API limitation; this is documented in the parameter description so the LLM / caller surfaces a clear expectation.