### PR TITLE
fix: preserve credentials on transient token refresh errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,16 +139,25 @@ async function initializeCredentials(): Promise<void> {
       if (credentials) {
         await saveCredentials(credentials);
       }
-    } catch (error) {
-      // Token refresh failed - credentials might be invalid
-      // Clear them so user can re-authenticate
-      console.error('Failed to refresh token on startup:', error);
-      credentials = null;
-      // Optionally delete invalid credentials file
-      try {
-        await fs.unlink(getCredentialsPath());
-      } catch {
-        // Ignore errors deleting file
+    } catch (error: any) {
+      // Only wipe credentials on definitive auth revocation (invalid_grant).
+      // Transient errors (network, timeout, 5xx) should NOT destroy saved creds.
+      const isAuthRevoked = error?.response?.data?.error === 'invalid_grant'
+        || error?.message?.includes('invalid_grant')
+        || error?.code === 401;
+
+      if (isAuthRevoked) {
+        console.error('Refresh token revoked — clearing credentials:', error?.message);
+        credentials = null;
+        try {
+          await fs.unlink(getCredentialsPath());
+        } catch {
+          // Ignore errors deleting file
+        }
+      } else {
+        // Keep credentials in memory (and on disk) — the refresh token is likely still valid.
+        // The next API call will retry via ensureValidToken().
+        console.error('Transient token refresh error on startup (credentials preserved):', error?.message);
       }
     }
   }


### PR DESCRIPTION
## Summary
Currently, any failure during the startup token refresh in `initializeCredentials()` deletes the saved credentials file, forcing manual re-authentication. This includes transient failures (network errors, timeouts, 5xx responses).

This PR narrows the credential wipe to definitive auth revocations only (`invalid_grant` or HTTP 401). Transient errors leave credentials intact so the next API call can retry via `ensureValidToken()`.

## Repro
1. Start the server while offline (or during a Google API blip).
2. The startup `refreshAccessToken()` throws.
3. Before this fix: credentials file is deleted → user must re-run the OAuth flow.
4. After this fix: credentials are preserved; the next valid call refreshes normally.

## Change
- Detect revocation via `error.response.data.error === 'invalid_grant'`, message includes `invalid_grant`, or `error.code === 401`.
- Only the revocation path clears in-memory + on-disk credentials.
- Transient errors log and preserve creds.

## Test plan
- [x] Simulated transient failure (DNS down): credentials persist, recover next call.
- [x] Revoked refresh token (revoked in Google account): credentials wiped as before.