### PR TITLE
fix: don't kill the server when the OAuth callback port is in use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -389,11 +389,36 @@ server.registerTool(
       }
     });
 
-    // Start the server on the configured port
-    authServer.listen(currentRedirectPort, () => {
-      console.error(`Temporary authentication server running at http://localhost:${currentRedirectPort}/`);
-      console.error('Waiting for authentication...');
-    });
+    // Start the server on the configured port.
+    // listen() reports EADDRINUSE as an async 'error' event, not a throw. With no
+    // listener attached that is an unhandled 'error' and Node kills the process —
+    // taking the whole MCP server down mid-session. The port is fixed (the redirect
+    // URI is registered server-side, so we cannot fall back to another port); await
+    // the bind and surface the failure as a normal tool error instead.
+    const srv = authServer;
+    try {
+      await new Promise<void>((resolve, reject) => {
+        srv.once('error', reject);
+        srv.listen(currentRedirectPort, () => {
+          srv.off('error', reject);
+          srv.on('error', (e) => console.error('OAuth callback server error:', e));
+          resolve();
+        });
+      });
+    } catch (e: any) {
+      authServer = null;
+      try { srv.close(); } catch {}
+      const detail =
+        e?.code === 'EADDRINUSE'
+          ? `OAuth callback port ${currentRedirectPort} is already in use, so authentication cannot start.\n\n` +
+            `Another Claude Code session most likely has an unfinished Google Tasks auth flow holding it. ` +
+            `Finish or abandon that flow (or close that session), then run 'authenticate' again.`
+          : `Could not open OAuth callback port ${currentRedirectPort}: ${e instanceof Error ? e.message : String(e)}`;
+      console.error(detail);
+      return { isError: true, content: [{ type: "text" as const, text: detail }] };
+    }
+    console.error(`Temporary authentication server running at http://localhost:${currentRedirectPort}/`);
+    console.error('Waiting for authentication...');
 
     // Generate the auth URL using the configured OAuth client (with matching redirect URI)
     const authUrl = oauth2Client.generateAuthUrl({


### PR DESCRIPTION
### The bug

If the OAuth callback port (`3000` by default) is already in use, the whole MCP server process dies instead of returning an error.

`authServer.listen()` reports `EADDRINUSE` as an asynchronous `'error'` event rather than throwing. No listener was attached to that event, so a busy port became an unhandled `'error'` and Node terminated the process.

What makes it hard to spot from the client side: the `authenticate` handler has already returned a perfectly normal-looking auth URL by the time the process dies. From the user's perspective the tool call succeeds, and then every tool from this server silently disappears from the session.

### Reproducing

Run two instances of the server concurrently and call `authenticate` on both. The second exits with code 1 and takes all of its tools with it.

This is wider than a narrow startup race. Nothing closes the callback server until a code arrives, the 60 s timer fires, `set-auth-code` runs, or the process exits — so **one abandoned auth flow holds the port for the lifetime of that process**. In my setup, servers stay up for days, so the window is effectively permanent once someone starts an auth flow and walks away.

### Why not just pick a free port

That was my first instinct, and it doesn't work. If the OAuth client is a **Web application** type, Google matches `redirect_uri` exactly — port included — and any port not registered on the client returns `redirect_uri_mismatch`. I verified this against the live authorization endpoint: a registered port succeeds, an arbitrary one is rejected.

So a busy callback port has to be *surfaced* as an error; it cannot be worked around by probing for a free one.

Related, and possibly worth a separate cleanup: `src/index.ts` still contains `isPortAvailable` and `findAvailablePort`, which are defined but never called, sitting right next to the comment `// no dynamic port changes to avoid OAuth mismatch`. They look like the fix for this bug but are unreachable. Happy to remove them in this PR if you'd prefer — I left them alone to keep the diff focused.

### The change

Await the bind, and convert a failed bind into a normal tool error:

- Attach a one-shot `'error'` listener and wrap `listen()` in a promise, so `EADDRINUSE` is caught instead of killing the process.
- On failure, null out `authServer`, close the half-open server, and return `isError: true` with a message that explains what is holding the port and what to do about it.
- On success, swap the one-shot rejector for a long-lived `'error'` handler that logs, so a later socket error also can't take the process down.

No behavior change on the happy path.

### Notes

+30 / −5, one file (`src/index.ts`). No new dependencies. The same fix applies to any MCP server using this callback pattern — I've applied it to three others locally.
